### PR TITLE
Fix RefreshIndicator onRefresh Future

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -124,7 +124,7 @@ class ChoiceList extends StatelessWidget {
               ),
             );
           }),
-      onRefresh: () {},
+      onRefresh: () async {},
     );
   }
 }


### PR DESCRIPTION
## Summary
- ensure `onRefresh` returns `Future<void>` so `RefreshIndicator` works

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684155c84cf483279e94f4997d811977