### PR TITLE
Fix minor issues and add basic widget test

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -124,7 +124,7 @@ class ChoiceList extends StatelessWidget {
               ),
             );
           }),
-      onRefresh: () {},
+      onRefresh: () async {},
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,7 +29,7 @@ class _MainPageState extends State<MainPage> {
     HomePage(),
     Text('Index 1: 视频'),
     Text('Index 2: 讲讲'),
-    Text('Index 2: 我的'),
+    Text('Index 3: 我的'),
   ];
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter application.
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
 # followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
+# Both the version and the build number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # In Android, build-name is used as versionName while build-number used as versionCode.
 # Read more about Android versioning at https://developer.android.com/studio/publish/versioning

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_news/main.dart';
+
+void main() {
+  testWidgets('bottom navigation contains four tabs', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: MainPage()));
+
+    expect(find.byType(BottomNavigationBar), findsOneWidget);
+    expect(find.text('首页'), findsOneWidget);
+    expect(find.text('视频'), findsOneWidget);
+    expect(find.text('讲讲'), findsOneWidget);
+    expect(find.text('我的'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- correct a comment in `pubspec.yaml`
- fix label indexing in main page
- fix `onRefresh` callback
- add a simple widget test

## Testing
- `flutter test ./test/widget_test.dart` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684155c81c708327bcdf36323624e07f